### PR TITLE
Reduce boilerplate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## 0.4.0 - TBD
 
-Initial tagged release.
-
 ### Added
 
-Nothing.
+- [#36](https://github.com/xtreamwayz/html-form-validator/pull/36) adds the `FormFactory->validateRequest()` to handle
+  PSR-7 requests and reduce boilerplate code needed to build, validate and render forms.
 
 ### Deprecated
 
@@ -21,7 +20,6 @@ Nothing.
 ### Fixed
 
 Nothing.
-
 
 ## 0.3.0 - 2016-02-22
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "zendframework/zend-servicemanager": "^3.0",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-uri": "^2.5",
-        "zendframework/zend-stdlib": "^2.7|^3.0"
+        "zendframework/zend-stdlib": "^2.7|^3.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/docs/wiki/Example-Zend-Expressive-Action.md
+++ b/docs/wiki/Example-Zend-Expressive-Action.md
@@ -89,25 +89,23 @@ class ContactAction
             'token' => $session->get('csrf'),
         ]));
 
-        // Check if the form is submitted
-        if ($request->getMethod() === 'POST') {
-            // Validate form
-            $validationResult = $form->validate((array) $request->getParsedBody());
-            
-            // Check if the validation result is valid 
-            if ($validationResult->isValid()) {
-                // Get filter submitted values
-                $data = $validationResult->getValues();
-
-                // Process data
-
-                return new RedirectResponse('/');
-            }
+        // Validate PSR-7 request and return a ValidationResponseInterface 
+        // It should only start validation if it was a post and if there are submitted values
+        $validationResult = $form->validateRequest($request);
+        
+        // It should be valid if it was a post and if there are no validation messages
+        if ($validationResult->isValid()) {
+            // Get filter submitted values
+            $data = $validationResult->getValues();
+        
+            // Process data
+        
+            return new RedirectResponse('/');
         }
-
-        // Display form and inject error messages and submitted values if needed
-        return new HtmlResponse($this->template->render('backend::cattle/edit', [
-            'form' => isset($validationResult) ? $form->asString($validationResult) : $form->asString(),
+        
+        // Display the form and inject the validation messages if there are any
+        return new HtmlResponse($this->template->render('app::edit', [
+            'form' => $form->asString($validationResult),
         ]));
     }
 }

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,17 +1,19 @@
-There are only 3 methods that are needed to get you started.
+There are only 4 steps needed to get you started.
 
 ```php
-// Load the html form into the FormFactory
+// Build the form
 $form = FormFactory::fromHtml($htmlForm);
 
 // Validate the form
 $result = $form->validate($_POST);
 
-// Display the form
-echo $form->asString();
+// Process validation result
+if ($result->isValid()) {
+    $data = $result->getValues();
+}
 
-// Display the form with the submitted values and validation messages 
-echo $form->asString($validationResult);
+// Render the form
+echo $form->asString();
 ```
 
 The HTML5 standard validation rules are added for you [[input elements|API Form Elements]] so you don't need to 
@@ -39,69 +41,28 @@ A full blown text input might look like:
        data-validators="" />
 ```
 
-Using this in a controller action method could look like this:
+Let's go through all the steps needed to get this working inside a controller action method.
+
+## 1. Build the form
+
+Create the form from html. Nothing fancy here. In this case a template renderer is used and the default values are 
+injected.
 
 ```php
-// Build the form validation
+// Build the form
 $form = FormFactory::fromHtml($this->template->render('app::form', [
-    'token'  => $session->get('csrf'),
-]));
-
-// Check if the request was a post
-if ($request->getMethod() === 'POST') {
-    // Validate the result
-    $validationResult = $form->validate((array) $request->getParsedBody());
-
-    // If the submitted data is valid...
-    if ($validationResult->isValid()) {
-        // Get filtered submitted values
-        $data = $validationResult->getValues();
-
-        // Process data
-
-        // Redirect to
-        return new RedirectResponse('/');
-    }
-}
-
-// Display the form and inject the validation messages if there are any
-return new HtmlResponse($this->template->render('app::edit', [
-    'form' => isset($validationResult) ? $form->asString($validationResult) : $form->asString(),
+    'token' => $session->get('csrf'),
 ]));
 ```
 
-## Handling PSR-7 Post Requests
+## 2. Validate the form
 
-But wait, there is still a lot of boilerplate code. This can be done with less code if there is a
-[PSR-7 requests](http://www.php-fig.org/psr/psr-7/).
-
-In stead of using `$form->validate($submittedData)` there is a method to handle PSR-7 requests and do some magic for 
-you: `$validationResult = $form->validateRequest($request);`.
+The easiest way is if you use a framework that uses [PSR-7 requests](http://www.php-fig.org/psr/psr-7/).
 
 ```php
-// Build the form validation
-$form = FormFactory::fromHtml($this->template->render('app::form', [
-    'token'  => $session->get('csrf'),
-]));
-
 // Validate PSR-7 request and return a ValidationResponseInterface 
 // It should only start validation if it was a post and if there are submitted values
 $validationResult = $form->validateRequest($request);
-
-// It should be valid if it was a post and if there are no validation messages
-if ($validationResult->isValid()) {
-    // Get filter submitted values
-    $data = $validationResult->getValues();
-
-    // Process data
-
-    return new RedirectResponse('/');
-}
-
-// Display the form and inject the validation messages if there are any
-return new HtmlResponse($this->template->render('app::edit', [
-    'form' => $form->asString($validationResult),
-]));
 ```
 
 If you use a framework that doesn't handle PSR-7 requests, you can still reduce boilerplate code by passing the 
@@ -111,7 +72,54 @@ request method yourself:
 $validationResult = $form->validate($submittedData, $_SERVER['REQUEST_METHOD']);
 ```
 
-## Custom Validators and Filters
+You can also leave the method validation out. It won't check for a valid `POST` method. 
+
+```php
+$validationResult = $form->validate($submittedData);
+```
+
+## 3. Process validation result
+
+Submitted data should be valid if it was a post and there are no validation messages set. 
+
+```php
+// It should be valid if it was a post and if there are no validation messages
+if ($validationResult->isValid()) {
+    // Get filter submitted values
+    $data = $validationResult->getValues();
+
+    // Process data
+
+    return new RedirectResponse('/');
+}
+```
+
+If you didn't use the PSR-7 request method, you might want to check for a valid post method yourself:
+ 
+```php
+if ($_SERVER['REQUEST_METHOD'] == 'POST' && $validationResult->isValid()) {
+    // ...
+}
+```
+
+## 4. Render the form
+
+Last step is rendering the form and injecting the submitted values and validation messages.
+
+```php
+// Render the form
+return new HtmlResponse($this->template->render('app::edit', [
+    'form' => $form->asString($validationResult),
+]));
+```
+
+If you don't want the values and messages injected for you, just leave out the validation result:
+
+```php
+echo $form->asString();
+```
+
+## Optional: Custom Validators and Filters
 
 Setting up custom validators and filters is a bit more work but it isn't complicated. Instead of creating the 
 FormFactory with its static `fromHtml` method, the constructor is needed with a configured Zend\InputFilter\Factory 

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -5,6 +5,7 @@ namespace Xtreamwayz\HTMLFormValidator;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\InputFilter\Factory;
 use Zend\InputFilter\InputFilterInterface;
 
@@ -101,10 +102,20 @@ final class FormFactory implements FormFactoryInterface
         return $this->document->saveHTML();
     }
 
+    public function validateRequest(ServerRequestInterface $request)
+    {
+        if ($request->getMethod() !== 'POST') {
+            // Not a post request, skip validation
+            return new ValidationResult([], [], [], $request->getMethod());
+        }
+
+        return $this->validate((array) $request->getParsedBody(), $request->getMethod());
+    }
+
     /**
      * @inheritdoc
      */
-    public function validate(array $data)
+    public function validate(array $data, $method = null)
     {
         $inputFilter = $this->factory->createInputFilter([]);
 
@@ -125,7 +136,8 @@ final class FormFactory implements FormFactoryInterface
         return new ValidationResult(
             $inputFilter->getRawValues(),
             $inputFilter->getValues(),
-            $messages
+            $messages,
+            $method
         );
     }
 

--- a/src/FormFactoryInterface.php
+++ b/src/FormFactoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace Xtreamwayz\HTMLFormValidator;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\InputFilter\Factory;
 
 interface FormFactoryInterface
@@ -35,11 +36,19 @@ interface FormFactoryInterface
     public function asString(ValidationResultInterface $result = null);
 
     /**
-     * Validate the loaded form with the data
-     *
-     * @param array $data
+     * @param ServerRequestInterface $request
      *
      * @return ValidationResultInterface
      */
-    public function validate(array $data);
+    public function validateRequest(ServerRequestInterface $request);
+
+    /**
+     * Validate the loaded form with the data
+     *
+     * @param array       $data   the submitted data to be validated
+     * @param null|string $method the request method (POST, GET, etc.)
+     *
+     * @return ValidationResultInterface
+     */
+    public function validate(array $data, $method = null);
 }

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -20,13 +20,19 @@ final class ValidationResult implements ValidationResultInterface
     private $messages;
 
     /**
+     * @var null|string
+     */
+    private $method;
+
+    /**
      * @inheritdoc
      */
-    public function __construct(array $rawValues, array $values, array $messages)
+    public function __construct(array $rawValues, array $values, array $messages, $method = null)
     {
         $this->rawValues = $rawValues;
         $this->values = $values;
         $this->messages = $messages;
+        $this->method = $method;
     }
 
     /**
@@ -34,7 +40,7 @@ final class ValidationResult implements ValidationResultInterface
      */
     public function isValid()
     {
-        return empty($this->messages);
+        return (empty($this->messages) && ($this->method === null || $this->method == 'POST'));
     }
 
     /**

--- a/src/ValidationResultInterface.php
+++ b/src/ValidationResultInterface.php
@@ -7,21 +7,25 @@ interface ValidationResultInterface
     /**
      * ValidationResult constructor.
      *
-     * @param array $rawInputData
-     * @param array $validatedData
-     * @param array $errors
+     * @param array       $rawInputData
+     * @param array       $validatedData
+     * @param array       $errors
+     * @param null|string $method
      */
-    public function __construct(array $rawInputData, array $validatedData, array $errors);
+    public function __construct(array $rawInputData, array $validatedData, array $errors, $method = null);
 
     /**
      * Check if the validation was successful
+     *
+     * If there are no validation messages set and the request method is null or POST,
+     * the validation result object is considered valid.
      *
      * @return bool
      */
     public function isValid();
 
     /**
-     * Get error messages
+     * Get validation messages
      *
      * @return array
      */

--- a/test/FormFactoryTest.php
+++ b/test/FormFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace XtreamwayzTest\HTMLFormValidator;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Xtreamwayz\HTMLFormValidator\FormFactory;
+use Xtreamwayz\HTMLFormValidator\ValidationResult;
+
+class FormFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    private $rawValues = [
+        'foo' => 'bar',
+        'baz' => ' qux ',
+    ];
+
+    private $values = [
+        'foo' => 'bar',
+        'baz' => 'qux',
+    ];
+
+    private $messages = [
+        'foo' => [
+            'regexNotMatch' => 'The input does not match against pattern \'/^\d+$/\'',
+        ]
+    ];
+
+    public function testPsrPostRequestIsValid()
+    {
+        $htmlForm = '
+            <input type="text" name="foo" />
+            <input type="text" name="baz" data-filters="stringtrim" />
+        ';
+
+        $form = FormFactory::fromHtml($htmlForm);
+        $request = $this ->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getParsedBody()->willReturn($this->rawValues);
+
+        $result = $form->validateRequest($request->reveal());
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertEquals($this->rawValues, $result->getRawValues());
+        $this->assertEquals($this->values, $result->getValues());
+        $this->assertEquals([], $result->getMessages());
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testPsrGetRequestIsNotValid()
+    {
+        $htmlForm = '
+            <input type="text" name="foo" />
+            <input type="text" name="baz" data-filters="stringtrim" />
+        ';
+
+        $form = FormFactory::fromHtml($htmlForm);
+        $request = $this ->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('GET');
+        $request->getParsedBody()->willReturn($this->rawValues);
+
+        $result = $form->validateRequest($request->reveal());
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertEquals([], $result->getRawValues());
+        $this->assertEquals([], $result->getValues());
+        $this->assertEquals([], $result->getMessages());
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testPsrPostRequestHasMessages()
+    {
+        $htmlForm = '
+            <input type="text" name="foo" pattern="^\d+$" />
+            <input type="text" name="baz" data-filters="stringtrim" />
+        ';
+
+        $form = FormFactory::fromHtml($htmlForm);
+        $request = $this ->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getParsedBody()->willReturn($this->rawValues);
+
+        $result = $form->validateRequest($request->reveal());
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertEquals($this->rawValues, $result->getRawValues());
+        $this->assertEquals($this->values, $result->getValues());
+        $this->assertEquals($this->messages, $result->getMessages());
+        $this->assertFalse($result->isValid());
+    }
+}

--- a/test/ValidationResultTest.php
+++ b/test/ValidationResultTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace XtreamwayzTest\HTMLFormValidator;
+
+use Xtreamwayz\HTMLFormValidator\ValidationResult;
+
+class ValidationResultTest extends \PHPUnit_Framework_TestCase
+{
+    private $rawValues = [
+        'foo' => 'bar',
+        'baz' => ' qux ',
+    ];
+
+    private $values = [
+        'foo' => 'bar',
+        'baz' => 'qux',
+    ];
+
+    private $messages = [
+        'foo' => [
+            'regexNotMatch' => '',
+            'notInArray' => '',
+        ]
+    ];
+
+    public function testValuesAreAvailable()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, $this->messages, null);
+
+        $this->assertEquals($this->rawValues, $result->getRawValues());
+        $this->assertEquals($this->values, $result->getValues());
+        $this->assertEquals($this->messages, $result->getMessages());
+    }
+
+    public function testResultIsValid()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, [], null);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testPostResultIsValid()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, [], 'POST');
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testResultWithMessagesIsNotValid()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, $this->messages, null);
+
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testPostResultWithMessagesIsNotValid()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, $this->messages, 'POST');
+
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testGetResultIsNotValid()
+    {
+        $result = new ValidationResult($this->rawValues, $this->values, $this->messages, 'GET');
+
+        $this->assertFalse($result->isValid());
+    }
+}


### PR DESCRIPTION
Make this work:

```php
// Generate form and set defaults
$form = FormFactory::fromHtml($this->template->render('app::form', [
    'token'  => $session->get('csrf'),
]));

// Validate PSR-7 request and return a ValidationResponseInterface 
// It should only start validation if it was a post and if there are submitted values
$validationResult = $form->validateRequest($request);

// It should be valid if it was a post and if there are no validation messages
if ($validationResult->isValid()) {
    // Get filter submitted values
    $data = $validationResult->getValues();

    // Process data

    return new RedirectResponse('/');
}

// Display form and inject error messages and submitted values if there are any
return new HtmlResponse($this->template->render('app::edit', [
    'form' => $form->asString($validationResult),
]));
```

closes #35 