### PR TITLE
Accept objects for default data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.6.0 - TBD
+
+### Added
+
+- [#52](https://github.com/xtreamwayz/html-form-validator/pull/52) adds accepting objects for default data.
+  No need to convert entity or DTO classes to arrays anymore to populate default data.
+
+  ```php
+  class Entity
+  {
+      public function getFoo()
+      {
+          return 'bar';
+      }
+  }
+
+  $form = FormFactory::fromHtml($htmlForm, new Entity());
+  ```
+
+### Deprecated
+
+Nothing.
+
+### Removed
+
+Nothing.
+
+### Fixed
+
+Nothing.
+
 ## 0.6.0 - 2016-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 0.6.0 - TBD
+## 0.7.0 - TBD
 
 ### Added
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -16,8 +16,8 @@ if ($result->isValid()) {
 echo $form->asString();
 ```
 
-The HTML5 standard validation rules are added for you [[input elements|API Form Elements]] so you don't need to 
-repeat those over and over again. And then there are the special attributes with trigger standard validation: 
+The HTML5 standard validation rules are added for you [[input elements|API Form Elements]] so you don't need to
+repeat those over and over again. And then there are the special attributes with trigger standard validation:
 - [[max|API Attributes#max]]
 - [[min|API Attributes#min]]
 - [[step|API Attributes#step]]
@@ -27,7 +27,7 @@ repeat those over and over again. And then there are the special attributes with
 - [[pattern|API Attributes#pattern]]
 - [[required|API Attributes#required]], [[aria-required|API Attributes#aria-required]]
 
-And if you need more validation or specific filters there is a [[data-filters|API Attributes#data-filters]] and 
+And if you need more validation or specific filters there is a [[data-filters|API Attributes#data-filters]] and
 [[data-validators|API Attributes#data-validators]] attribute.
 
 A full blown text input might look like:
@@ -47,7 +47,7 @@ Let's go through all the steps needed to get this working inside a controller ac
 
 ### 1. Build the form
 
-Create the form from html. Nothing fancy here. In this case a template renderer is used and the default values are 
+Create the form from html. Nothing fancy here. In this case a template renderer is used and the default values are
 injected.
 
 ```php
@@ -57,24 +57,47 @@ $form = FormFactory::fromHtml($this->template->render('app::form', [
 ]));
 ```
 
+You can set default data if required. This must be either an array or an object with public get methods for each
+element name. In this example the array and the object will give the same result: Setting the `bar` as the value
+for `foo`.
+
+```php
+$form = FormFactory::fromHtml($htmlForm, $defaultdata);
+
+// Array
+$defaultData = [
+    'foo' => 'bar',
+];
+
+// Object
+class SomeClassToUseAsDefaultData
+{
+    public function getFoo()
+    {
+        return 'bar';
+    }
+}
+$defaultData = new SomeClassToUseAsDefaultData();
+```
+
 ### 2. Validate the form
 
 The easiest way is if you use a framework that uses [PSR-7 requests](http://www.php-fig.org/psr/psr-7/).
 
 ```php
-// Validate PSR-7 request and return a ValidationResponseInterface 
+// Validate PSR-7 request and return a ValidationResponseInterface
 // It should only start validation if it was a post and if there are submitted values
 $validationResult = $form->validateRequest($request);
 ```
 
-If you use a framework that doesn't handle PSR-7 requests, you can still reduce boilerplate code by passing the 
+If you use a framework that doesn't handle PSR-7 requests, you can still reduce boilerplate code by passing the
 request method yourself:
 
 ```php
 $validationResult = $form->validate($submittedData, $_SERVER['REQUEST_METHOD']);
 ```
 
-You can also leave the method validation out. It won't check for a valid `POST` method. 
+You can also leave the method validation out. It won't check for a valid `POST` method.
 
 ```php
 $validationResult = $form->validate($submittedData);
@@ -82,7 +105,7 @@ $validationResult = $form->validate($submittedData);
 
 ### 3. Process validation result
 
-Submitted data should be valid if it was a post and there are no validation messages set. 
+Submitted data should be valid if it was a post and there are no validation messages set.
 
 ```php
 // It should be valid if it was a post and if there are no validation messages
@@ -97,7 +120,7 @@ if ($validationResult->isValid()) {
 ```
 
 If you didn't use the PSR-7 request method, you might want to check for a valid post method yourself.
- 
+
 ```php
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && $validationResult->isValid()) {
     // ...
@@ -148,9 +171,9 @@ $validationResult->isClicked();
 
 ## Custom Validators and Filters
 
-Setting up custom validators and filters is a bit more work but it isn't complicated. Instead of creating the 
-FormFactory with its static `fromHtml` method, the constructor is needed with a configured Zend\InputFilter\Factory 
-and a Interop\Container\ContainerInterface. 
+Setting up custom validators and filters is a bit more work but it isn't complicated. Instead of creating the
+FormFactory with its static `fromHtml` method, the constructor is needed with a configured Zend\InputFilter\Factory
+and a Interop\Container\ContainerInterface.
 
 ```php
 $config = [
@@ -186,6 +209,6 @@ $result = $form->validate($_POST);
 // Display the plain form
 echo $form->asString();
 
-// Display the form with the submitted values and validation messages 
+// Display the form with the submitted values and validation messages
 echo $form->asString($validationResult);
 ```

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -54,7 +54,7 @@ final class FormFactory implements FormFactoryInterface
     /**
      * @inheritdoc
      */
-    public function __construct(string $htmlForm, Factory $factory = null, array $defaultValues = [])
+    public function __construct(string $htmlForm, Factory $factory = null, $defaultValues = [])
     {
         $this->factory = $factory ?: new Factory();
 
@@ -74,7 +74,7 @@ final class FormFactory implements FormFactoryInterface
     /**
      * @inheritdoc
      */
-    public static function fromHtml(string $htmlForm, array $defaultValues = []) : FormFactoryInterface
+    public static function fromHtml(string $htmlForm, $defaultValues = []) : FormFactoryInterface
     {
         return new self($htmlForm, null, $defaultValues);
     }
@@ -240,18 +240,28 @@ final class FormFactory implements FormFactoryInterface
     /**
      * Set values and element checked and selected states
      *
-     * @param array $data
-     * @param bool  $force
+     * @param array|object $data
+     * @param bool         $force
      */
-    private function setData(array $data, $force = false)
+    private function setData($data, $force = false)
     {
         foreach ($this->getNodeList() as $name => $node) {
-            if (!array_key_exists($name, $data)) {
-                // No value set for this element
-                continue;
-            }
+            if (is_array($data)) {
+                if (!array_key_exists($name, $data)) {
+                    // No value set for this element
+                    continue;
+                }
 
-            $value = $data[$name];
+                $value = $data[$name];
+            } else {
+                $method = 'get' . $name;
+                if (!is_object($data) || !method_exists($data, $method)) {
+                    // No object or method is not available
+                    continue;
+                }
+
+                $value = $data->$method();
+            }
 
             $reuseSubmittedValue = filter_var(
                 $node->getAttribute('data-reuse-submitted-value'),

--- a/src/FormFactoryInterface.php
+++ b/src/FormFactoryInterface.php
@@ -14,19 +14,19 @@ interface FormFactoryInterface
      *
      * @param string       $htmlForm
      * @param null|Factory $factory
-     * @param array        $defaultValues
+     * @param array|object $defaultValues
      */
-    public function __construct(string $htmlForm, Factory $factory = null, array $defaultValues = []);
+    public function __construct(string $htmlForm, Factory $factory = null, $defaultValues = []);
 
     /**
      * Load html form and optionally set default data
      *
-     * @param string $htmlForm
-     * @param array  $defaultValues
+     * @param string       $htmlForm
+     * @param array|object $defaultValues
      *
      * @return FormFactoryInterface
      */
-    public static function fromHtml(string $htmlForm, array $defaultValues = []) : FormFactoryInterface;
+    public static function fromHtml(string $htmlForm, $defaultValues = []) : FormFactoryInterface;
 
     /**
      * Return form as a string. Optionally inject the error messages for the result.

--- a/test/FormFactoryTest.php
+++ b/test/FormFactoryTest.php
@@ -1,12 +1,13 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace XtreamwayzTest\HTMLFormValidator;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Xtreamwayz\HTMLFormValidator\FormFactory;
 use Xtreamwayz\HTMLFormValidator\ValidationResult;
+use XtreamwayzTest\HTMLFormValidator\TestAsset\EntityWithMethodsForValues;
 
 class FormFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -134,7 +135,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 <input type="text" name="baz" data-filters="stringtrim" />
             </form>';
 
-        $form = FormFactory::fromHtml($htmlForm, new GenericObjectWithMethods());
+        $form = FormFactory::fromHtml($htmlForm, new EntityWithMethodsForValues());
 
         self::assertContains('<input type="text" name="foo" value="bar">', $form->asString());
         self::assertContains('<input type="text" name="baz" value="qux">', $form->asString());
@@ -148,22 +149,9 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 <input type="text" name="baz" data-filters="stringtrim" />
             </form>';
 
-        $form = new FormFactory($htmlForm, null, new GenericObjectWithMethods());
+        $form = new FormFactory($htmlForm, null, new EntityWithMethodsForValues());
 
         self::assertContains('<input type="text" name="foo" value="bar">', $form->asString());
         self::assertContains('<input type="text" name="baz" value="qux">', $form->asString());
-    }
-}
-
-class GenericObjectWithMethods
-{
-    public function getFoo()
-    {
-        return 'bar';
-    }
-
-    public function getBaz()
-    {
-        return 'qux';
     }
 }

--- a/test/FormFactoryTest.php
+++ b/test/FormFactoryTest.php
@@ -125,4 +125,45 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         self::assertContains('<input type="text" name="foo" value="bar">', $form->asString());
         self::assertContains('<input type="text" name="baz" value="qux">', $form->asString());
     }
+
+    public function testSetValuesStaticallyFromObject()
+    {
+        $htmlForm = '
+            <form action="/" method="post">
+                <input type="text" name="foo" data-reuse-submitted-value="true" />
+                <input type="text" name="baz" data-filters="stringtrim" />
+            </form>';
+
+        $form = FormFactory::fromHtml($htmlForm, new GenericObjectWithMethods());
+
+        self::assertContains('<input type="text" name="foo" value="bar">', $form->asString());
+        self::assertContains('<input type="text" name="baz" value="qux">', $form->asString());
+    }
+
+    public function testSetValuesWithConstructorFromObject()
+    {
+        $htmlForm = '
+            <form action="/" method="post">
+                <input type="text" name="foo" data-reuse-submitted-value="true" />
+                <input type="text" name="baz" data-filters="stringtrim" />
+            </form>';
+
+        $form = new FormFactory($htmlForm, null, new GenericObjectWithMethods());
+
+        self::assertContains('<input type="text" name="foo" value="bar">', $form->asString());
+        self::assertContains('<input type="text" name="baz" value="qux">', $form->asString());
+    }
+}
+
+class GenericObjectWithMethods
+{
+    public function getFoo()
+    {
+        return 'bar';
+    }
+
+    public function getBaz()
+    {
+        return 'qux';
+    }
 }

--- a/test/TestAsset/EntityWithMethodsForValues.php
+++ b/test/TestAsset/EntityWithMethodsForValues.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace XtreamwayzTest\HTMLFormValidator\TestAsset;
+
+class EntityWithMethodsForValues
+{
+    public function getFoo()
+    {
+        return 'bar';
+    }
+
+    public function getBaz()
+    {
+        return 'qux';
+    }
+}


### PR DESCRIPTION
  No need to convert entity or DTO classes to arrays anymore to populate default data.

  ```php
  class Entity
  {
      public function getFoo()
      {
          return 'bar';
      }
  }

  $form = FormFactory::fromHtml($htmlForm, new Entity());
  ```