### PR TITLE
Enforce UTF-8 encoding to prevent issues with libxml2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#56](https://github.com/xtreamwayz/html-form-validator/pull/56) fixes unicode characters support. UTF-8 is now
+  enforced internally to make this happen. To prevent unwanted output only the first form is returned in
+  `FormFactory->asString()`.
 
 ## 0.7.0 - 2016-04-16
 

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -63,8 +63,11 @@ final class FormFactory implements FormFactoryInterface
 
         // Ignore invalid tag errors during loading (e.g. datalist)
         libxml_use_internal_errors(true);
-        // Don't add missing doctype, html and body
-        $this->document->loadHTML($htmlForm, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        // Enforce UTF-8 encoding and don't add missing doctype, html and body
+        $this->document->loadHTML(
+            '<?xml version="1.0" encoding="UTF-8"?>' . $htmlForm,
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
         libxml_use_internal_errors(false);
 
         // Inject default values (from models etc)
@@ -101,7 +104,8 @@ final class FormFactory implements FormFactoryInterface
 
         $this->document->formatOutput = true;
 
-        return $this->document->saveHTML();
+        // Return the first form only to prevent returning the XML declaration
+        return $this->document->saveHTML($this->document->getElementsByTagName('form')->item(0));
     }
 
     public function validateRequest(ServerRequestInterface $request) : ValidationResultInterface

--- a/test/Fixtures/utf8-encoding.test
+++ b/test/Fixtures/utf8-encoding.test
@@ -1,0 +1,30 @@
+--TEST--
+<test description>
+--HTML-FORM--
+<form action="/" method="post">
+    <input type="text" name="valid_value" required value="Îñţérñåţîöñåļîžåţîöñ" />
+    <input type="text" name="valid_default" required />
+    <input type="text" name="valid_reuse" required data-reuse-submitted-value="true" />
+</form>
+--DEFAULT-VALUES--
+{
+    "valid_default": "Îñţérñåţîöñåļîžåţîöñ"
+}
+--SUBMITTED-VALUES--
+{
+    "valid_value": "Îñţérñåţîöñåļîžåţîöñ",
+    "valid_default": "Îñţérñåţîöñåļîžåţîöñ",
+    "valid_reuse": "Îñţérñåţîöñåļîžåţîöñ"
+}
+--EXPECTED-VALUES--
+{
+    "valid_value": "Îñţérñåţîöñåļîžåţîöñ",
+    "valid_default": "Îñţérñåţîöñåļîžåţîöñ",
+    "valid_reuse": "Îñţérñåţîöñåļîžåţîöñ"
+}
+--EXPECTED-FORM--
+<form action="/" method="post">
+    <input type="text" name="valid_value" required value="Îñţérñåţîöñåļîžåţîöñ" />
+    <input type="text" name="valid_default" required value="Îñţérñåţîöñåļîžåţîöñ" />
+    <input type="text" name="valid_reuse" required value="Îñţérñåţîöñåļîžåţîöñ" />
+</form>


### PR DESCRIPTION
The DOMDocument does not detect UTF-8 encoding properly. Auto prefixing the html form with a XML declaration enforces UTF-8. To prevent returning the XML declaration, only the first found form in the DOMDocument is returned.