### PR TITLE
zend-servicemanager is required by zend-filter and zend-validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#58](https://github.com/xtreamwayz/html-form-validator/pull/58) fixes the zend-servicemanager dependency.
+  It's now installed by default since zend-filter and zend-validator depend on the PluginManager classes.
 
 ## 0.8.0 - 2016-04-27
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-uri": "^2.5",
         "zendframework/zend-stdlib": "^2.7|^3.0",
+        "zendframework/zend-servicemanager": "^2.7|^3.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
-        "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-servicemanager": "^3.0"
+        "squizlabs/php_codesniffer": "^2.3"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "To support third-party validators and filters"
@@ -37,10 +37,8 @@
             "@test"
         ],
         "cs": "php vendor/squizlabs/php_codesniffer/scripts/phpcs",
-        "test": "php vendor/phpunit/phpunit/phpunit --report-useless-tests",
-        "coverage": "php vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage"
+        "test": "php vendor/phpunit/phpunit/phpunit --report-useless-tests"
     },
-
     "autoload": {
         "psr-4": {
             "Xtreamwayz\\HTMLFormValidator\\": "src/"


### PR DESCRIPTION
If zend-servicemanager is not yet installed as a dependency, there will be errors. It looks like the way the inputfilter is designed, it requires the PluginManager classes.