### PR TITLE
Respect request method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#59](https://github.com/xtreamwayz/html-form-validator/pull/59) checks if a request method is set and if it's a post
+  when calling `validate()`. If it wasn't a post, it skips validation.
+  If the method isn't set, it always runs the validation.
 
 ### Deprecated
 

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -108,13 +108,11 @@ final class FormFactory implements FormFactoryInterface
         return $this->document->saveHTML($this->document->getElementsByTagName('form')->item(0));
     }
 
+    /**
+     * @inheritdoc
+     */
     public function validateRequest(ServerRequestInterface $request) : ValidationResultInterface
     {
-        if ($request->getMethod() !== 'POST') {
-            // Not a post request, skip validation
-            return new ValidationResult([], [], [], $request->getMethod());
-        }
-
         return $this->validate((array) $request->getParsedBody(), $request->getMethod());
     }
 
@@ -123,6 +121,11 @@ final class FormFactory implements FormFactoryInterface
      */
     public function validate(array $data, $method = null) : ValidationResultInterface
     {
+        if ($method !== null && $method !== 'POST') {
+            // Not a post request, skip validation
+            return new ValidationResult([], [], [], $method);
+        }
+
         $inputFilter = $this->factory->createInputFilter([]);
 
         // Add all validators and filters to the InputFilter


### PR DESCRIPTION
If the request method is set for validate(), it should check if it was a post. If it wasn't a post, it shouldn't run the validation.