### PR TITLE
Add support for input arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,12 @@ matrix:
       env:
         - DEPS=latest
         - TEST_COVERAGE=true
-    - php: nightly
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: nightly
+    - php: 7.3
       env:
         - DEPS=latest
-  allow_failures:
-    - php: nightly
 
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.2.0 - TBD
+## 1.2.0 - 2019-07-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.2.0 - TBD
+
+### Added
+
+- [#77](https://github.com/xtreamwayz/html-form-validator/pull/77) adds support for array input fields.
+  Input checkbox fields with names like `cars[]` will be treated as arrays.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.1.1 - 2018-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # html-form-validator
 
-[![Build Status](https://travis-ci.com/xtreamlabs/html-form-validator.svg?branch=master)](https://travis-ci.com/xtreamwayz/html-form-validator)
-[![Code Coverage](https://scrutinizer-ci.com/g/xtreamwayz/html-form-validator/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/xtreamwayz/html-form-validator/?branch=master)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/xtreamwayz/html-form-validator/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/xtreamwayz/html-form-validator/?branch=master)
+[![Build Status](https://travis-ci.com/xtreamwayz/html-form-validator.svg?branch=master)](https://travis-ci.com/xtreamwayz/html-form-validator)
 [![Packagist](https://img.shields.io/packagist/v/xtreamwayz/html-form-validator.svg)](https://packagist.org/packages/xtreamwayz/html-form-validator)
 [![Packagist](https://img.shields.io/packagist/vpre/xtreamwayz/html-form-validator.svg)](https://packagist.org/packages/xtreamwayz/html-form-validator)
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.3.x-dev"
         },
         "zf": {
             "config-provider": "Xtreamwayz\\HTMLFormValidator\\ConfigProvider"

--- a/docs/wiki/API-Form-Elements.md
+++ b/docs/wiki/API-Form-Elements.md
@@ -330,6 +330,16 @@ Resources:
 <input type="checkbox" name="checkbox" value="value" />
 ```
 
+Input arrays are supported. The following will return an array `['cars'=>['audi', 'bmw']]`.
+
+```html
+<form action="/" method="post">
+    <input type="checkbox" name="cars[]" value="audi" checked />
+    <input type="checkbox" name="cars[]" value="bmw" checked />
+    <input type="checkbox" name="cars[]" value="volkswagen" />
+</form>
+```
+
 Resources:
 [whatwg](https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox))
 

--- a/test/FormElementArraytest.php
+++ b/test/FormElementArraytest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace XtreamwayzTest\HTMLFormValidator;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Xtreamwayz\HTMLFormValidator\FormFactory;
+use Xtreamwayz\HTMLFormValidator\ValidationResult;
+use function preg_replace;
+use const LIBXML_HTML_NODEFDTD;
+use const LIBXML_HTML_NOIMPLIED;
+use const LIBXML_NOBLANKS;
+
+class FormElementArraytest extends TestCase
+{
+    public function testCheckboxArrayIsValid() : void
+    {
+        $html = '
+            <form action="/" method="post">
+                <input type="checkbox" name="cars[]" value="audi" data-reuse-submitted-value="true" />
+                <input type="checkbox" name="cars[]" value="bmw" data-reuse-submitted-value="true" />
+                <input type="checkbox" name="cars[]" value="volkswagen" data-reuse-submitted-value="true" />
+            </form>';
+
+        $form    = (new FormFactory())->fromHtml($html);
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getParsedBody()->willReturn([
+            'cars' => ['audi', 'bmw'],
+        ]);
+
+        $result = $form->validateRequest($request->reveal());
+
+        self::assertInstanceOf(ValidationResult::class, $result);
+        self::assertEquals(['cars' => ['audi', 'bmw']], $result->getValues());
+        self::assertEquals([], $result->getMessages());
+        self::assertTrue($result->isValid());
+
+        $expected = '
+            <form action="/" method="post">
+                <input type="checkbox" name="cars[]" value="audi" checked />
+                <input type="checkbox" name="cars[]" value="bmw" checked />
+                <input type="checkbox" name="cars[]" value="volkswagen" />
+            </form>';
+
+        $actual = $form->asString($result);
+        self::assertEquals(
+            $this->getDomDocument($expected),
+            $this->getDomDocument($actual),
+            'Failed asserting that the form is rendered correctly.'
+        );
+    }
+
+    private function getDomDocument($html)
+    {
+        $doc = new \DOMDocument('1.0', 'utf-8');
+
+        $doc->preserveWhiteSpace = false;
+        // Don't add missing doctype, html and body
+        //libxml_use_internal_errors(true);
+        $doc->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS);
+        //libxml_use_internal_errors(false);
+        // Remove whitespace for better comparison
+
+        return preg_replace('~\s+~i', ' ', $doc->saveHTML());
+    }
+}


### PR DESCRIPTION
This PR adds support for input arrays.

    <form action="/" method="post">
        <input type="checkbox" name="cars[]" value="audi" data-reuse-submitted-value="true" />
        <input type="checkbox" name="cars[]" value="bmw" data-reuse-submitted-value="true" />
        <input type="checkbox" name="cars[]" value="volkswagen" data-reuse-submitted-value="true" />
    </form>

It will return the value as an array:

        [
            'cars' => [
                'audi',
                'bmw',
            ],
        ]

And will check the checkboxes when needed:

    <form action="/" method="post">
        <input type="checkbox" name="cars[]" value="audi" checked />
        <input type="checkbox" name="cars[]" value="bmw" checked />
        <input type="checkbox" name="cars[]" value="volkswagen" />
    </form>

Closes #66